### PR TITLE
Normalize domain inputs in the library entry point

### DIFF
--- a/src/pshtt/cli.py
+++ b/src/pshtt/cli.py
@@ -102,13 +102,8 @@ def main():
     else:
         domains = args["INPUT"]
 
-    domains = utils.format_domains(domains)
-
-    # If the user wants to sort them, sort them in place.
-    if args["--sorted"]:
-        domains.sort()
-
     options = {
+        "sorted": args["--sorted"],
         "user_agent": args["--user-agent"],
         "timeout": args["--timeout"],
         "cache-third-parties": args["--cache-third-parties"],

--- a/src/pshtt/pshtt.py
+++ b/src/pshtt/pshtt.py
@@ -1808,7 +1808,11 @@ def initialize_external_data(
 
 
 def inspect_domains(domains, options):
-    """Run inspect() against each of the given domains with the given options."""
+    """Normalize and inspect domains, optionally sorting by normalized name."""
+    domains = utils.format_domains(domains)
+    if options.get("sorted"):
+        domains.sort()
+
     # Override timeout, user agent, preload cache, default CA bundle
     global TIMEOUT, USER_AGENT, THIRD_PARTIES_CACHE, CA_FILE, PT_INT_CA_FILE, STORE
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,10 +5,11 @@ import os
 import sys
 import tempfile
 import unittest
+from unittest.mock import call, patch
 
 # cisagov Libraries
 from pshtt import pshtt as _pshtt
-from pshtt.cli import to_csv
+from pshtt.cli import main, to_csv
 from pshtt.models import Domain, Endpoint
 
 
@@ -121,3 +122,30 @@ class TestToCSV(unittest.TestCase):
         # in the package. This should never fail, as the above assert should
         # catch any changes in the header columns.
         self.assertEqual(header, ",".join(_pshtt.HEADERS))
+
+
+class TestDomainNormalization(unittest.TestCase):
+    """Test CLI normalization and sorting through the library."""
+
+    @patch("pshtt.pshtt.initialize_external_data")
+    @patch("pshtt.pshtt.inspect", side_effect=lambda domain: {"Domain": domain})
+    @patch("pshtt.cli.to_json", side_effect=lambda results, filename: list(results))
+    def test_sorted_domains(self, mock_output, mock_inspect, mock_initialize):
+        """Sort normalized names and remove at most one www prefix."""
+        with patch.object(
+            sys,
+            "argv",
+            [
+                "pshtt",
+                "example.org",
+                "https://www.example.com",
+                "www.www.example.net",
+                "--sorted",
+                "--json",
+            ],
+        ):
+            main()
+        self.assertEqual(
+            mock_inspect.call_args_list,
+            [call("example.com"), call("example.org"), call("www.example.net")],
+        )

--- a/tests/test_pshtt.py
+++ b/tests/test_pshtt.py
@@ -3,7 +3,7 @@
 # Standard Python Libraries
 import datetime
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 # Third-Party Libraries
 from unittest_parametrize import ParametrizedTestCase, param, parametrize
@@ -13,6 +13,7 @@ from pshtt.models import Domain, Endpoint
 from pshtt.pshtt import (
     certificate_is_expired,
     https_check,
+    inspect_domains,
     is_live,
     is_strictly_forces_https,
 )
@@ -282,3 +283,53 @@ class TestStrictlyForcesHttps(unittest.TestCase):
 
         self.assertIsInstance(result, bool)
         self.assertTrue(result)
+
+
+class TestInspectDomains(ParametrizedTestCase):
+    """Test input normalization through the library entry point."""
+
+    @parametrize(
+        ("domains", "expected"),
+        [
+            param(["https://www.example.com"], ["example.com"], id="https"),
+            param(["http://www.example.com"], ["example.com"], id="http"),
+            param(["www.example.com"], ["example.com"], id="www"),
+            param(["example.com:8443"], ["example.com:8443"], id="port"),
+            param(["www.www.example.com"], ["www.example.com"], id="one_prefix"),
+            param(
+                ["example.org", "example.com"],
+                ["example.org", "example.com"],
+                id="order",
+            ),
+            param([], [], id="empty"),
+        ],
+    )
+    @patch("pshtt.pshtt.initialize_external_data")
+    @patch("pshtt.pshtt.inspect", side_effect=lambda domain: domain)
+    def test_normalization(self, mock_inspect, mock_initialize, domains, expected):
+        """Normalize inputs once without changing their order or the input list."""
+        original = domains.copy()
+        self.assertEqual(list(inspect_domains(domains, {})), expected)
+        self.assertEqual(
+            mock_inspect.call_args_list, [call(domain) for domain in expected]
+        )
+        self.assertEqual(domains, original)
+
+    @patch("pshtt.pshtt.initialize_external_data")
+    @patch("pshtt.pshtt.inspect", side_effect=lambda domain: domain)
+    def test_sort_normalized_domains(self, mock_inspect, mock_initialize):
+        """Sort on normalized names when requested, preserving duplicates."""
+        domains = ["example.org", "https://www.example.com", "www.example.com"]
+        self.assertEqual(
+            list(inspect_domains(domains, {"sorted": True})),
+            ["example.com", "example.com", "example.org"],
+        )
+
+    @patch("pshtt.pshtt.initialize_external_data")
+    @patch("pshtt.pshtt.inspect", side_effect=lambda domain: domain)
+    def test_iterable_input(self, mock_inspect, mock_initialize):
+        """Accept an iterable of domain names."""
+        domains = (domain for domain in ["https://www.example.com", "www.example.org"])
+        self.assertEqual(
+            list(inspect_domains(domains, {})), ["example.com", "example.org"]
+        )


### PR DESCRIPTION
## 🗣 Description

Normalize input domains in `inspect_domains()` using the existing `utils.format_domains()` helper. Library callers currently pass inputs such as `https://www.example.com` straight to `inspect()`, whereas the CLI strips those prefixes first.

The CLI now delegates normalization and its optional sorting to the library. Sorting happens after normalization, and normalization runs only once, preserving the existing treatment of a name such as `www.www.example.com`.

## 💭 Motivation and context

Fixes #133. Existing bare-domain input keeps its order unless sorting is requested. Explicit ports and duplicate entries are preserved, and the input list is not modified. The existing helper's normalization rules are unchanged.

## 🧪 Testing

- `pytest -o addopts='' -q`: **41 passed, 5 skipped** on macOS, CPython 3.10.20 x86_64 with SSLyze 4.1.0. The five skips already exist upstream.
- Baseline suite: 31 passed, 5 skipped. Before the implementation change, six of the ten new test cases failed; all pass afterward.
- Regression coverage includes HTTP/HTTPS and www prefixes, stripping only one www prefix, explicit ports, empty input, iterables, input immutability, order/duplicates, and the actual CLI parser with `--sorted --json`.
- External data initialization and network inspection are mocked; no public domains are scanned.
- `pre-commit run --files src/pshtt/cli.py src/pshtt/pshtt.py tests/test_cli.py tests/test_pshtt.py`: passed, including Black, Flake8, isort, mypy, and Bandit.
- `git diff --check`: passed.

The x86_64 runtime was used because the existing ARM macOS `nassl` wheel fails to import with a missing `_SSLv2_method` symbol. No dependency changes are included.

## ✅ Pre-approval checklist

- [x] Focused change and informative title.
- [x] Contribution instructions checked and related issue linked.
- [x] Regression tests added and local suite passed.
- [x] Relevant pre-commit checks passed.

## ✅ Pre-merge checklist

- [ ] Maintainer review and CI completed.
